### PR TITLE
Move tools-version preamble to the top

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,5 @@
+// swift-tools-version:4.2
+
 // Copyright 2017-2022 Provide Technologies Inc.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +13,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-// swift-tools-version:4.2
 
 import PackageDescription
 


### PR DESCRIPTION
Our nightly process flagged this: https://github.com/SwiftPackageIndex/PackageList/runs/6750304894?check_suite_focus=true#step:5:234